### PR TITLE
Implements method for building unicode fonts

### DIFF
--- a/src/Thinreports/Generator/PDF/Font.php
+++ b/src/Thinreports/Generator/PDF/Font.php
@@ -31,6 +31,13 @@ class Font
         'Times New Roman' => 'Times'
     );
 
+    static public function init()
+    {
+        foreach (array_keys(self::$builtin_unicode_fonts) as $name) {
+            self::installBuiltinFont($name);
+        }
+    }
+
     /**
      * @param string $name
      * @return string

--- a/test/unit/Thinreports/Generator/PDF/FontTest.php
+++ b/test/unit/Thinreports/Generator/PDF/FontTest.php
@@ -10,6 +10,21 @@ class FontTest extends TestCase
         Font::$installed_builtin_fonts = array();
     }
 
+    function test_init()
+    {
+        Font::init();
+
+        $this->assertEquals(
+            array(
+                'IPAMincho',
+                'IPAPMincho',
+                'IPAGothic',
+                'IPAPGothic'
+            ),
+            array_keys(Font::$installed_builtin_fonts)
+        );
+    }
+
     function test_getFontName()
     {
         $this->assertEquals('Helvetica', Font::getFontName('Helvetica'));


### PR DESCRIPTION
The following method creates TCPDF format font of each built-in unicode font.

``` php
Thinreports\Generator\PDF\Font::init();
```

However, even if the method has not called, TCPDF format font will be created automatically. Why need to call the method?

最初の一度だけとはいえ、TCPDF形式のフォント生成はとても時間がかかります。なので、Web サーバを起動するときなどで、予めフォントを作成しておくことによって遅延を解消することができます。
