### PR TITLE
Rename method for pre-building unicode fonts

### DIFF
--- a/src/Thinreports/Generator/PDF/Font.php
+++ b/src/Thinreports/Generator/PDF/Font.php
@@ -33,7 +33,7 @@ class Font
         'Times New Roman' => 'Times'
     );
 
-    static public function init()
+    static public function build()
     {
         foreach (array_keys(self::$builtin_unicode_fonts) as $name) {
             self::installBuiltinFont($name);

--- a/test/unit/Thinreports/Generator/PDF/FontTest.php
+++ b/test/unit/Thinreports/Generator/PDF/FontTest.php
@@ -10,9 +10,9 @@ class FontTest extends TestCase
         Font::$installed_builtin_fonts = array();
     }
 
-    function test_init()
+    function test_build()
     {
-        Font::init();
+        Font::build();
 
         $this->assertEquals(
             array(


### PR DESCRIPTION
This is improvement for #7.
## Changes

``` php
<?php
Thinreports\Generator\PDF\Font::init();
```

to

``` php
<?php
Thinreports\Generator\PDF\Font::build();
```
