### PR TITLE
0.8.x does not support thinreports 0.9+

### DIFF
--- a/src/Thinreports/Layout.php
+++ b/src/Thinreports/Layout.php
@@ -17,7 +17,7 @@ class Layout
 {
     const FILE_EXT_NAME = 'tlf';
     const COMPATIBLE_VERSION_RANGE_START = '>= 0.8.2';
-    const COMPATIBLE_VERSION_RANGE_END   = '< 1.0.0';
+    const COMPATIBLE_VERSION_RANGE_END   = '< 0.9.0';
 
     /**
      * @param string $filename

--- a/test/unit/Thinreports/LayoutTest.php
+++ b/test/unit/Thinreports/LayoutTest.php
@@ -34,7 +34,7 @@ class LayoutTest extends TestCase
         }
 
         try {
-            Layout::parse('{"version":"1.0.0"}');
+            Layout::parse('{"version":"0.9.0"}');
             $this->fail();
         } catch (Exception\IncompatibleLayout $e) {
             // OK


### PR DESCRIPTION
Currently, thinreports-php 0.8.x does not support thinreports 0.9 formatted `.tlf`. thinreports-php 0.9+ will supports.